### PR TITLE
change gravity CLI argument to not use globby pattern

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build project
         run: npm run build
       - name: Run Gravity
-        run: npx @gravityci/cli dist/**/*
+        run: npx @gravityci/cli ./dist/
         env:
           GRAVITY_TOKEN: ${{ secrets.GRAVITY_TOKEN }}
           GRAVITY_HOST: ${{ vars.GRAVITY_HOST }}


### PR DESCRIPTION
I want to test if the example suggested in Gravity Dashboard works:

```
name: Gravity
on:
push:
  branches:
    - main
pull_request: {}

jobs:
build:
  name: Run Gravity
  runs-on: ubuntu-latest
  steps:
    - uses: actions/checkout@v4
    - uses: actions/setup-node@v4
    - run: npm ci
    - name: build
      run: npm run build # build your project – this should be a production build
    - run: npx @gravityci/cli ./dist/ # run Gravity CLI against the build artifacts
      env:
        GRAVITY_TOKEN: ${{ secrets.GRAVITY_TOKEN }}
```